### PR TITLE
docs: complete JC documentation and add JASM documentation

### DIFF
--- a/JASM_Documentation.md
+++ b/JASM_Documentation.md
@@ -1,0 +1,207 @@
+# JinX Assembly (JASM) Documentation
+
+JASM is the planned low-level assembly language target for the JinX toolchain.
+
+At the current stage of the repository, JASM is a **design document / planned target**. The JC compiler backend (`generator.py`) is still unfinished, so this document defines the intended direction and conventions for implementation.
+
+---
+
+## 1) Purpose of JASM
+
+JASM is intended to:
+- Serve as the intermediate/target representation produced from JC.
+- Stay human-readable for debugging early boot/kernel development.
+- Map cleanly onto machine code in later compiler stages.
+
+Typical future flow:
+
+```text
+JC source (.jc) -> JC parser/AST -> JASM (.jasm) -> machine code / binary image
+```
+
+---
+
+## 2) File Extension
+
+Recommended extension:
+
+- `.jasm`
+
+Example: `kernel.jasm`
+
+---
+
+## 3) Planned Core Structure
+
+A JASM file should be structured as:
+1. Optional metadata/directives.
+2. Section declarations.
+3. Labels/functions.
+4. Instructions.
+5. Data declarations.
+
+Illustrative skeleton:
+
+```asm
+.section text
+.global k_main
+
+k_main:
+    mov r0, 0xB8000
+    ret
+```
+
+---
+
+## 4) Lexical Conventions (Proposed)
+
+### Comments
+Single-line comments:
+
+```asm
+; this is a comment
+```
+
+### Labels
+A label defines an addressable symbol:
+
+```asm
+k_main:
+```
+
+### Instruction format
+
+```asm
+<mnemonic> <operand1>, <operand2>
+```
+
+Examples:
+
+```asm
+mov r0, 1
+add r0, r1
+jmp loop_start
+```
+
+---
+
+## 5) Planned Directives
+
+Common directives to support first:
+
+- `.section <name>` - switch section (`text`, `data`, `rodata`, etc.).
+- `.global <symbol>` - export a symbol.
+- `.extern <symbol>` - import external symbol.
+- `.byte`, `.word`, `.dword`, `.qword` - data constants.
+- `.ascii` / `.asciz` - string data.
+
+Example:
+
+```asm
+.section rodata
+msg:
+    .asciz "Hello"
+```
+
+---
+
+## 6) Registers and ABI (Draft)
+
+The final register set and ABI are not yet fixed. Until defined, use placeholder register names in examples:
+
+- `r0`, `r1`, `r2`, ...
+- `sp` (stack pointer), `bp` (base pointer), `pc` (program counter), if applicable.
+
+Planned ABI topics (to finalize later):
+- Argument passing strategy.
+- Return value register(s).
+- Caller/callee-saved register rules.
+- Stack alignment.
+
+---
+
+## 7) Instruction Classes (Planned)
+
+### Data movement
+- `mov dst, src`
+- `load dst, [addr]`
+- `store [addr], src`
+
+### Arithmetic/logic
+- `add`, `sub`, `mul`, `div`
+- `and`, `or`, `xor`, `not`
+- `cmp`
+
+### Control flow
+- `jmp label`
+- `jz label`, `jnz label`, etc.
+- `call label`
+- `ret`
+
+### Stack
+- `push reg`
+- `pop reg`
+
+Mnemonic set may change when architecture decisions are finalized.
+
+---
+
+## 8) Mapping JC -> JASM (Planned)
+
+### Function declaration
+JC:
+
+```c
+func k_main() u32 {
+  u32 screen = 0xB8000;
+}
+```
+
+Possible JASM shape:
+
+```asm
+.section text
+.global k_main
+k_main:
+    mov r0, 0xB8000
+    ; local "screen" assigned from r0 / stack slot (backend-defined)
+    ret
+```
+
+### Variable declarations
+A JC local declaration with constant initialization should lower into either:
+- A register assignment.
+- A stack slot write.
+
+Choice depends on register allocation and function complexity.
+
+---
+
+## 9) Error Handling Expectations
+
+Future JASM assembler/compiler stages should report:
+- Unknown mnemonics.
+- Invalid operand counts/types.
+- Undefined labels/symbols.
+- Section/directive misuse.
+- Numeric literal overflow for operand width.
+
+---
+
+## 10) Current Reality in This Repository
+
+- JASM codegen is not implemented yet.
+- `OS/compiler/generator.py` is currently empty.
+- `OS/compiler/main.py` currently stops after lexing/parsing and reports success.
+
+This document therefore defines the initial contract the backend can implement next.
+
+---
+
+## 11) Recommended Next Implementation Steps
+
+1. Define a small architecture-neutral instruction IR.
+2. Implement `generator.py` to lower parsed JC declarations/functions into preliminary JASM.
+3. Emit `.jasm` files from `main.py` as an output artifact.
+4. Add round-trip tests with tiny JC programs (`main.jc`, `stdio.jc`).
+5. Freeze v0.1 JASM syntax and update this document accordingly.

--- a/JinX-C_Documentation.md
+++ b/JinX-C_Documentation.md
@@ -1,109 +1,201 @@
-# JinX-C (JC)
-This is a custom programming language used for JinX.
-It is built to be just like C.
+# JinX-C (JC) Documentation
 
-## Documentation Notes
-In this documentation, all code snippets will be marked as C for code formatting in Github. However, all code is JC code.
+JinX-C (JC) is the custom systems language for JinX. It is intentionally C-like, but the current compiler only supports a small teaching subset while the project is in early development.
 
-## Comments
-Currently, the only way to use a comment is:
-```C
+## Current Status
+
+The current Python compiler implements:
+- Lexing/tokenization.
+- Parsing for `#include` directives.
+- Parsing for function declarations with optional typed arguments and an optional return type.
+- Parsing for simple variable declarations with direct initialization.
+
+It does **not** yet implement full code generation, full expression parsing, or full control-flow semantics.
+
+---
+
+## 1) File Structure and Entry Point
+
+JC source files use the `.jc` extension.
+
+Example:
+
+```c
+#include <stdio.h>
+
+func main() u32 {
+  u32 code = 0;
+}
+```
+
+Notes:
+- `func` declares a function.
+- A return type can appear after the parameter list (for example: `u32`).
+- The parser currently focuses on declarations and structure, not full execution semantics.
+
+---
+
+## 2) Comments
+
+Single-line comments are supported:
+
+```c
 // This is a comment
 ```
-As of the time of writing, `/* comment */` syntax is not supported.
 
-## Syntax
-JC, like C, runs from the `main()` function.
-A good example of some JC code is as follows:
-```C
+Block comments (`/* ... */`) are not currently supported.
+
+---
+
+## 3) Supported Primitive Types
+
+The lexer/parser currently recognize these keywords as language types:
+
+- `u8` - 8-bit unsigned integer.
+- `u32` - 32-bit unsigned integer.
+- `ptr` - raw pointer value.
+- `str` - string type.
+- `bool` - boolean keyword (recognized by lexer; parser support is still partial in declarations).
+
+---
+
+## 4) Includes
+
+The lexer recognizes include directives in this format:
+
+```c
 #include <stdio.h>
+```
 
-func main() u32 {
-  printf("Hello World!");
-  return 0;
+Currently, includes are parsed into the AST as top-level include nodes.
+
+---
+
+## 5) Functions
+
+### Syntax
+
+```c
+func <name>(<typed_args>) <return_type> {
+  // body
 }
 ```
 
-**Line 1**: `#include <stdio.h>` is to include a *header file*.
-In this case, the header in question is to let us use input/output functions such as `printf()` (used in line 4).
+Examples:
 
-**Line 2**: This is a blank line, and is ignored by the compiler.
-However, this makes the code more readable.
-
-**Line 3**: `main()` is the main function.
-All code in the curly brackets `{}` will be executed first.
-`u32` is used to declare the output type, which is an *32-bit unsigned integer*.
-If the `main()` function returns `1`, we assume an error has occured, and if it returns `0`, that means the code ran through and has completed running.
-
-**Line 4**: `printf()` is a function derived from the `include` statment at the start of the code.
-This function is used to output text to the screen.
-
-> [!IMPORTANT]
-> Every JC statement MUST end with a semicolon `;`. 
-
-**Line 5**: `return 0;` ends the program, as the main loop returns a value.
-If we returned `1`, then JinX will assume an error has occured, which caused termination.
-However, returning `0` will let JinX know that the program has closed without errors.
-
-**Line 6**: This is just the closing curly bracket `}` for the `main()` loop.
-
-> [!NOTE]
-> The entire `main()` can also be written as 
-> ```C
->  func main() u32 {printf("Hello World!");return 0;}
-> ```
-> However, we add line breaks for readability.
-
-## JC Output
-JC uses the `<stdio.h>` library (which is named for consistancy with C).
-This provides the `printf()` function.
-An example of output:
-```C
-#include <stdio.h>
-
-func main() u32 {
-  printf("Hello World!\n");
-  printf("I am reading JC documentation.\n");
-  printf("I want to learn how to use JinX.")
-  return 0;
+```c
+func k_main() u32 {
+  u32 screen = 0xB8000;
 }
 ```
-Here, note that a `\n` is required.
-However, in JC, the `<stdio.h>` library also contains another function, which is the `println()` function.
-The above code could be rewritten as:
-```C
-#include <stdio.h>
 
-func main() u32 {
-  println("Hello World!");
-  println("I am reading JC documentation.");
-  println("I want to learn how to use JinX.")
-  return 0;
+```c
+func putchar(u8 c) {
+  ptr vga = 0xB8000;
 }
 ```
-The `println()` function simply adds a `\n` automatically.
 
-> [!TIP]
-> To avoid unexpected behavior in output, it is reccomended to use `println` for the majority of logging, with `printf` only being used for very specific cases.
+### Parameters
 
-## Variables
-Similar to C, JC also requires a type declaration in variables.
-JC has the following types:
-* `u8`: 8-bit unsigned integer.
-* `u32`: 32-bit unsigned integer.
-* `ptr`: A raw memory pointer.
-* `str`: A sequence of characters. In JC, this is internally treated as a pointer to a null-terminated array of u8 bytes.
-* `bool`: A boolean value, either true (1) or false (0). Internally stored as a u8.
-Example usage:
-```C
+Parameters are typed and follow a C-like style:
+
+```c
+func add(u32 a, u32 b) u32 {
+  u32 sum = a;
+}
+```
+
+The parser is designed to support comma-separated arguments.
+
+---
+
+## 6) Variable Declarations
+
+Inside functions, the parser currently supports declarations with immediate initialization:
+
+```c
 u32 count = 10;
-str message = "Hello world!";
-ptr video_memory = 0xB8000;
+str text = "Hello";
+ptr vga = 0xB8000;
 ```
 
+Supported initializer token categories are currently:
+- Number literals (including hex like `0xB8000`).
+- String literals.
+- Identifiers.
 
-## Functions
-Functions are declared as such:
-```C
+---
 
+## 7) Literals and Tokens
+
+### Numeric literals
+- Decimal: `123`
+- Hexadecimal: `0xB8000`
+
+### String literals
+- Double-quoted only:
+
+```c
+"Hello world"
 ```
+
+### Operators (tokenized)
+The lexer tokenizes operators such as:
+- `=` `+` `-` `*` `/`
+- `==` `!=` `<=` `>=`
+
+> Tokenization support does not automatically mean full semantic/codegen support yet.
+
+---
+
+## 8) Punctuation and Statement Rules
+
+Recognized punctuation tokens include:
+- `;` `(` `)` `{` `}` `[` `]`
+
+Use semicolons for declarations/statements:
+
+```c
+u32 x = 1;
+```
+
+---
+
+## 9) Minimal Working Example
+
+```c
+#include <stdio.h>
+
+func main() u32 {
+  u32 result = 0;
+}
+```
+
+Run compiler (from repository root):
+
+```bash
+python OS/compiler/main.py OS/kernel/main.jc
+```
+
+The current compiler prints:
+1. Tokens.
+2. Parsed AST.
+3. A success message if lexing/parsing complete.
+
+---
+
+## 10) Known Limitations (Current Compiler)
+
+- No finished machine-code/JASM generation stage yet.
+- Parser handles only a subset of statements (currently strongest support is declaration parsing).
+- Control flow (`if`, `while`) is tokenized but not fully parsed/executed yet.
+- Return statements are tokenized but not fully lowered to backend output yet.
+
+---
+
+## 11) Planned Next Steps
+
+- Expand parser coverage for expressions and statements.
+- Implement backend code generation.
+- Add a documented standard library contract for built-ins like `println` and `putchar`.
+- Align JC documentation with JASM output format as backend stabilizes.

--- a/JinX-C_Documentation.md
+++ b/JinX-C_Documentation.md
@@ -140,10 +140,10 @@ Supported initializer token categories are currently:
 ```
 
 ### Operators (tokenized)
-The lexer tokenizes operators such as:
+The lexer currently tokenizes single-character operators such as:
 - `=` `+` `-` `*` `/`
-- `==` `!=` `<=` `>=`
 
+Multi-character comparison operators like `==`, `!=`, `<=`, and `>=` are not currently tokenized as single operators by the current compiler implementation.
 > Tokenization support does not automatically mean full semantic/codegen support yet.
 
 ---

--- a/README.md
+++ b/README.md
@@ -9,4 +9,8 @@ However, everything in the OS will be made from scratch, with a completely custo
 This is **not** a Build Your Own Linux project, as we will not neccecarily be using Linux systems.
 
 
+## Documentation
+- [JinX-C (JC) Documentation](./JinX-C_Documentation.md)
+- [JinX Assembly (JASM) Documentation](./JASM_Documentation.md)
+
 Copyright © 2026. All rights reserved.


### PR DESCRIPTION
### Motivation
- Finish and clarify the user-facing language reference for JinX-C (JC) so contributors understand the current compiler capability and constraints. 
- Provide a clear, versioned design target for the not-yet-implemented backend by introducing an initial JASM specification and roadmap. 
- Make the new documentation discoverable from the project entrypoint by adding links to `README.md`.

### Description
- Rewrote and expanded `JinX-C_Documentation.md` into a structured reference describing lexer/parser coverage, syntax examples, supported types, statement rules, known limitations, and next steps. 
- Added `JASM_Documentation.md` as a draft design/spec for the planned assembly target including file layout, directives, instruction classes, ABI notes, JC→JASM mapping examples, and an implementation roadmap. 
- Updated `README.md` to include links to `JinX-C_Documentation.md` and `JASM_Documentation.md` for easier navigation.

### Testing
- Ran the current compiler against `OS/kernel/main.jc` with `python OS/compiler/main.py OS/kernel/main.jc`, which produced tokens and an AST and reported "Compilation successful!".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed673ed6c48327b37d86826d165c16)